### PR TITLE
Minor Additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ All you need is a modern web browser.
 
 1.  **Clone the repository:**
     ```sh
-    git clone [https://github.com/scarrrrrlet/String-Encryption-and-Decryption.git](https://github.com/scarrrrrlet/String-Encryption-and-Decryption.git)
+    git clone https://github.com/scarrrrrlet/String-Encryption-and-Decryption.git
     ```
 2.  **Navigate to the project directory:**
     ```sh

--- a/index.html
+++ b/index.html
@@ -13,8 +13,10 @@
     <div class="container">
         <h1>Text Encryption & Decryption</h1>
 
+        <p id="text-input-err" class="error-msg">required field</p>
         <textarea id="text-input" placeholder="Enter your text here..."></textarea>
 
+        <p id="secret-key-err" class="error-msg">required field</p>
         <input type="password" id="secret-key" placeholder="Enter your secret key...">
 
         <div class="buttons">

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
 
         <button id="copy-button" onclick="copyToClipboard()">Copy</button>
     </div>
-    
+
     <script src="https://cdnjs.cloudflare.com/ajax/libs/crypto-js/4.1.1/crypto-js.min.js"></script>
     <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -42,15 +42,15 @@ function copyToClipboard() {
 
     if (textToCopy) {
         resultOutput.select();
-        resultOutput.setSelectionRange(0, 99999); 
+        resultOutput.setSelectionRange(0, 99999);
 
         try {
             document.execCommand('copy');
-            
+
             copyButton.textContent = 'Copied!';
             setTimeout(() => {
                 copyButton.textContent = 'Copy';
-            }, 2000); 
+            }, 2000);
 
         } catch (err) {
             console.error('Failed to copy text: ', err);

--- a/script.js
+++ b/script.js
@@ -30,6 +30,7 @@ function encryptText() {
     const text = textInput.value;
     const secretKey = secretInput.value;
 
+    resultOutput.classList.remove('error');
     resultOutput.value = "";
 
     if (!text || !secretKey) {
@@ -48,6 +49,7 @@ function decryptText() {
     const encryptedText = textInput.value.trim();
     const secretKey = secretInput.value;
 
+    resultOutput.classList.remove('error');
     resultOutput.value = "";
 
     if (!encryptedText || !secretKey) {
@@ -59,6 +61,7 @@ function decryptText() {
     }
 
     if (!base64Regex.test(encryptedText)) {
+        resultOutput.classList.add('error');
         resultOutput.value = "Invalid Base64."
         return
     }
@@ -73,6 +76,7 @@ function decryptText() {
         }
 
     } catch (e) {}
+    resultOutput.classList.add('error');
     resultOutput.value = "Decryption failed. Invalid key or ciphertext.";
 }
 

--- a/script.js
+++ b/script.js
@@ -12,7 +12,7 @@ function encryptText() {
 }
 
 function decryptText() {
-    const encryptedText = document.getElementById('text-input').value;
+    const encryptedText = document.getElementById('text-input').value.trim();
     const secretKey = document.getElementById('secret-key').value;
     const resultOutput = document.getElementById('result-output');
 

--- a/script.js
+++ b/script.js
@@ -2,6 +2,8 @@ const textInput = document.getElementById('text-input');
 const secretInput = document.getElementById('secret-key');
 const resultOutput = document.getElementById('result-output');
 
+resultOutput.value = "";
+
 const base64Regex = /^[A-Za-z0-9+\/]+={0,3}$/;
 
 function showError(input) {

--- a/script.js
+++ b/script.js
@@ -28,6 +28,8 @@ function encryptText() {
     const text = textInput.value;
     const secretKey = secretInput.value;
 
+    resultOutput.value = "";
+
     if (text && secretKey) {
         const encrypted = CryptoJS.AES.encrypt(text, secretKey).toString();
         resultOutput.value = encrypted;
@@ -42,6 +44,8 @@ function encryptText() {
 function decryptText() {
     const encryptedText = textInput.value.trim();
     const secretKey = secretInput.value;
+
+    resultOutput.value = "";
 
     if (encryptedText && secretKey) {
         try {

--- a/script.js
+++ b/script.js
@@ -2,6 +2,28 @@ const textInput = document.getElementById('text-input');
 const secretInput = document.getElementById('secret-key');
 const resultOutput = document.getElementById('result-output');
 
+function showError(input) {
+    input.classList.add('error');
+    const err = document.getElementById(input.id + '-err');
+    if (err){
+        err.classList.add('error-visible');
+    }
+    input.setAttribute('aria-invalid', 'true');
+}
+
+function clearError(input) {
+    input.classList.remove('error');
+    const err = document.getElementById(input.id + '-err');
+    if (err) {
+        err.classList.remove('error-visible');
+    }
+    input.removeAttribute('aria-invalid');
+}
+
+[textInput, secretInput].forEach(input =>
+    input.addEventListener('focus', () => clearError(input))
+)
+
 function encryptText() {
     const text = textInput.value;
     const secretKey = secretInput.value;
@@ -10,7 +32,10 @@ function encryptText() {
         const encrypted = CryptoJS.AES.encrypt(text, secretKey).toString();
         resultOutput.value = encrypted;
     } else {
-        alert("Please enter text and a secret key.");
+        if (!encryptedText)
+            showError(textInput);
+        if (!secretKey)
+            showError(secretInput);
     }
 }
 
@@ -33,7 +58,10 @@ function decryptText() {
             resultOutput.value = "Decryption failed. Invalid key or ciphertext.";
         }
     } else {
-        alert("Please enter the encrypted text and the secret key.");
+        if (!encryptedText)
+            showError(textInput);
+        if (!secretKey)
+            showError(secretInput);
     }
 }
 

--- a/script.js
+++ b/script.js
@@ -1,7 +1,10 @@
+const textInput = document.getElementById('text-input');
+const secretInput = document.getElementById('secret-key');
+const resultOutput = document.getElementById('result-output');
+
 function encryptText() {
-    const text = document.getElementById('text-input').value;
-    const secretKey = document.getElementById('secret-key').value;
-    const resultOutput = document.getElementById('result-output');
+    const text = textInput.value;
+    const secretKey = secretInput.value;
 
     if (text && secretKey) {
         const encrypted = CryptoJS.AES.encrypt(text, secretKey).toString();
@@ -12,9 +15,8 @@ function encryptText() {
 }
 
 function decryptText() {
-    const encryptedText = document.getElementById('text-input').value.trim();
-    const secretKey = document.getElementById('secret-key').value;
-    const resultOutput = document.getElementById('result-output');
+    const encryptedText = textInput.value.trim();
+    const secretKey = secretInput.value;
 
     if (encryptedText && secretKey) {
         try {
@@ -36,7 +38,6 @@ function decryptText() {
 }
 
 function copyToClipboard() {
-    const resultOutput = document.getElementById('result-output');
     const copyButton = document.getElementById('copy-button');
     const textToCopy = resultOutput.value;
 

--- a/script.js
+++ b/script.js
@@ -2,6 +2,8 @@ const textInput = document.getElementById('text-input');
 const secretInput = document.getElementById('secret-key');
 const resultOutput = document.getElementById('result-output');
 
+const base64Regex = /^[A-Za-z0-9+\/]+={0,3}$/;
+
 function showError(input) {
     input.classList.add('error');
     const err = document.getElementById(input.id + '-err');
@@ -48,6 +50,12 @@ function decryptText() {
     resultOutput.value = "";
 
     if (encryptedText && secretKey) {
+
+        if (!base64Regex.test(encryptedText)) {
+            resultOutput.value = "Invalid Base64."
+            return
+        }
+
         try {
             const decryptedBytes = CryptoJS.AES.decrypt(encryptedText, secretKey);
             const decryptedText = decryptedBytes.toString(CryptoJS.enc.Utf8);

--- a/script.js
+++ b/script.js
@@ -32,15 +32,16 @@ function encryptText() {
 
     resultOutput.value = "";
 
-    if (text && secretKey) {
-        const encrypted = CryptoJS.AES.encrypt(text, secretKey).toString();
-        resultOutput.value = encrypted;
-    } else {
+    if (!text || !secretKey) {
         if (!text)
             showError(textInput);
         if (!secretKey)
             showError(secretInput);
+        return;
     }
+
+    const encrypted = CryptoJS.AES.encrypt(text, secretKey).toString();
+    resultOutput.value = encrypted;
 }
 
 function decryptText() {
@@ -49,55 +50,54 @@ function decryptText() {
 
     resultOutput.value = "";
 
-    if (encryptedText && secretKey) {
-
-        if (!base64Regex.test(encryptedText)) {
-            resultOutput.value = "Invalid Base64."
-            return
-        }
-
-        try {
-            const decryptedBytes = CryptoJS.AES.decrypt(encryptedText, secretKey);
-            const decryptedText = decryptedBytes.toString(CryptoJS.enc.Utf8);
-
-            if(decryptedText) {
-                resultOutput.value = decryptedText;
-            } else {
-                resultOutput.value = "Decryption failed. Invalid key or ciphertext.";
-            }
-
-        } catch (e) {
-            resultOutput.value = "Decryption failed. Invalid key or ciphertext.";
-        }
-    } else {
+    if (!encryptedText || !secretKey) {
         if (!encryptedText)
             showError(textInput);
         if (!secretKey)
             showError(secretInput);
+        return;
     }
+
+    if (!base64Regex.test(encryptedText)) {
+        resultOutput.value = "Invalid Base64."
+        return
+    }
+
+    try {
+        const decryptedBytes = CryptoJS.AES.decrypt(encryptedText, secretKey);
+        const decryptedText = decryptedBytes.toString(CryptoJS.enc.Utf8);
+
+        if(decryptedText) {
+            resultOutput.value = decryptedText;
+            return;
+        }
+
+    } catch (e) {}
+    resultOutput.value = "Decryption failed. Invalid key or ciphertext.";
 }
 
 function copyToClipboard() {
     const copyButton = document.getElementById('copy-button');
     const textToCopy = resultOutput.value;
 
-    if (textToCopy) {
-        resultOutput.select();
-        resultOutput.setSelectionRange(0, 99999);
-
-        try {
-            document.execCommand('copy');
-
-            copyButton.textContent = 'Copied!';
-            setTimeout(() => {
-                copyButton.textContent = 'Copy';
-            }, 2000);
-
-        } catch (err) {
-            console.error('Failed to copy text: ', err);
-            alert('Sorry, your browser does not support this feature.');
-        }
-
-        window.getSelection().removeAllRanges();
+    if (!textToCopy) {
+        return;
     }
+
+    resultOutput.select();
+    resultOutput.setSelectionRange(0, 99999);
+
+    try {
+        document.execCommand('copy');
+
+        copyButton.textContent = 'Copied!';
+        setTimeout(() => {
+            copyButton.textContent = 'Copy';
+        }, 2000);
+    } catch (err) {
+        console.error('Failed to copy text: ', err);
+        alert('Sorry, your browser does not support this feature.');
+    }
+
+    window.getSelection().removeAllRanges();
 }

--- a/script.js
+++ b/script.js
@@ -36,7 +36,7 @@ function encryptText() {
         const encrypted = CryptoJS.AES.encrypt(text, secretKey).toString();
         resultOutput.value = encrypted;
     } else {
-        if (!encryptedText)
+        if (!text)
             showError(textInput);
         if (!secretKey)
             showError(secretInput);

--- a/style.css
+++ b/style.css
@@ -112,8 +112,8 @@ button:hover {
 
 #copy-button {
     display: block;
-    margin: 1.5rem auto 0; 
-    width: 180px; 
+    margin: 1.5rem auto 0;
+    width: 180px;
     padding: 10px 15px;
     border-radius: 6px;
     border: 1px solid #4f46e5;

--- a/style.css
+++ b/style.css
@@ -132,4 +132,22 @@ button:hover {
     color: white;
 }
 
+.error {
+    border-color: #d05858 !important;
+    box-shadow: 0 0 0 4px rgba(224,59,59,0.06);
+}
 
+.error-msg{
+    font-size: 13px;
+    color: #d05858;
+    height: 18px; /* reserve space */
+    /*visibility: hidden;*/
+    opacity: 0;
+    transition: visibility 0s linear .14s, opacity .14s;
+}
+
+.error-visible{
+    visibility: visible;
+    opacity: 1;
+    transition-delay: 0s;
+}

--- a/style.css
+++ b/style.css
@@ -135,6 +135,7 @@ button:hover {
 .error {
     border-color: #d05858 !important;
     box-shadow: 0 0 0 4px rgba(224,59,59,0.06);
+    color: #d05858;
 }
 
 .error-msg{


### PR DESCRIPTION
# Minor Additions
## Summary
- Trim text-input when decrypting so leading/trailing white space is ignored.
- Replace missing field alerts with a nice red boarder around the field and "required field" text.
- Give errors in the output box a red boarder and text.
- Add base64 validation for slightly more detailed error messages.
- Fix git clone command in readme (can't use markdown in codeblocks).
- Minor readability/maintainability improvements.

## Detailed by commit
- `b515874`: Trim text-input when decrypting so leading/trailing white space is ignored.
- `53c09e3`: Clean up miscellaneous spaces and tabs.
- `e8a78e6`: Factor out text input, secret input and result output `getElementById` calls for reuse.
- `49a28d6`: Replace missing field alerts with a nice red boarder around the field and "required field" text.
- `9aa97bb`: Clear the output before processing a request so that error messages/outputs do not carry over to the next request. This prevents the user from being confused if the output is still giving an invalid base64 error when they're actually missing the secret key.
- `b9b330d`: Fix bad git clone command in readme (can't use markdown in codeblocks).
- `4ae4cac`: Add base64 validation for slightly more detailed error messages.
- `39d47de`: My mistake, forgot to change `encryptedText` to `text` lol.
- `420a364`: Change branches to avoid nesting. This makes the code more readable and easier to think about.
- `31e4fac`: Gave result output a red boarder and text when displaying an error.
- `2e0e13d`: Reset result output on initialization. This causes the output not to persist over a refresh as it messes up the error message formatting.